### PR TITLE
Support `RemoveWatch`

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -27,6 +27,7 @@ const (
 	opCheck           = 13
 	opMulti           = 14
 	opReconfig        = 16
+	opRemoveWatches   = 18
 	opCreateContainer = 19
 	opCreateTTL       = 21
 	opClose           = -11
@@ -130,6 +131,30 @@ func (m AddWatchMode) String() string {
 	return "Unknown"
 }
 
+const (
+	WatcherTypeChildren WatcherType = 1
+	WatcherTypeData     WatcherType = 2
+	WatcherTypeAny      WatcherType = 3
+)
+
+var (
+	watcherTypeNames = map[WatcherType]string{
+		WatcherTypeChildren: "WatcherTypeChildren",
+		WatcherTypeData:     "WatcherTypeData",
+		WatcherTypeAny:      "WatcherTypeAny",
+	}
+)
+
+// WatcherType represents a type of watcher.
+type WatcherType int32
+
+func (m WatcherType) String() string {
+	if name := watcherTypeNames[m]; name != "" {
+		return name
+	}
+	return "Unknown"
+}
+
 // ErrCode is the error code defined by server. Refer to ZK documentations for more specifics.
 type ErrCode int32
 
@@ -153,6 +178,7 @@ var (
 	ErrSessionMoved            = errors.New("zk: session moved to another server, so operation is ignored")
 	ErrReconfigDisabled        = errors.New("attempts to perform a reconfiguration operation when reconfiguration feature is disabled")
 	ErrBadArguments            = errors.New("invalid arguments")
+	ErrNoWatcher               = errors.New("watcher does not exist")
 	// ErrInvalidCallback         = errors.New("zk: invalid callback specified")
 
 	errCodeToError = map[ErrCode]error{
@@ -173,6 +199,7 @@ var (
 		errSessionMoved:      ErrSessionMoved,
 		errZReconfigDisabled: ErrReconfigDisabled,
 		errBadArguments:      ErrBadArguments,
+		errNoWatcher:         ErrNoWatcher,
 	}
 )
 
@@ -210,6 +237,7 @@ const (
 	errClosing                 ErrCode = -116
 	errNothing                 ErrCode = -117
 	errSessionMoved            ErrCode = -118
+	errNoWatcher               ErrCode = -122
 	// Attempts to perform a reconfiguration operation when reconfiguration feature is disabled
 	errZReconfigDisabled ErrCode = -123
 )
@@ -250,6 +278,7 @@ var (
 		opSetWatches:      "setWatches",
 		opSetWatches2:     "setWatches2",
 		opAddWatch:        "addWatch",
+		opRemoveWatches:   "removeWatches",
 
 		opWatcherEvent: "watcherEvent",
 	}

--- a/structs.go
+++ b/structs.go
@@ -140,7 +140,7 @@ type statResponse struct {
 
 //
 
-type CheckVersionRequest PathVersionRequest
+type checkVersionRequest PathVersionRequest
 type closeRequest struct{}
 type closeResponse struct{}
 
@@ -159,14 +159,14 @@ type connectResponse struct {
 	Passwd          []byte
 }
 
-type CreateRequest struct {
+type createRequest struct {
 	Path  string
 	Data  []byte
 	Acl   []ACL
 	Flags int32
 }
 
-type CreateContainerRequest CreateRequest
+type createContainerRequest createRequest
 
 type CreateTTLRequest struct {
 	Path  string
@@ -177,7 +177,7 @@ type CreateTTLRequest struct {
 }
 
 type createResponse pathResponse
-type DeleteRequest PathVersionRequest
+type deleteRequest PathVersionRequest
 type deleteResponse struct{}
 
 type errorResponse struct {
@@ -241,7 +241,7 @@ type addWatchRequest struct {
 
 type addWatchResponse struct{}
 
-type SetDataRequest struct {
+type setDataRequest struct {
 	Path    string
 	Data    []byte
 	Version int32
@@ -281,6 +281,13 @@ type setWatches2Request struct {
 }
 
 type setWatches2Response struct{}
+
+type removeWatchesRequest struct {
+	Path string
+	Type WatcherType
+}
+
+type removeWatchesResponse struct{}
 
 type syncRequest pathRequest
 type syncResponse pathResponse
@@ -617,13 +624,13 @@ func requestStructForOp(op int32) interface{} {
 	case opClose:
 		return &closeRequest{}
 	case opCreate:
-		return &CreateRequest{}
+		return &createRequest{}
 	case opCreateContainer:
-		return &CreateContainerRequest{}
+		return &createContainerRequest{}
 	case opCreateTTL:
 		return &CreateTTLRequest{}
 	case opDelete:
-		return &DeleteRequest{}
+		return &deleteRequest{}
 	case opExists:
 		return &existsRequest{}
 	case opGetAcl:
@@ -639,19 +646,21 @@ func requestStructForOp(op int32) interface{} {
 	case opSetAcl:
 		return &setAclRequest{}
 	case opSetData:
-		return &SetDataRequest{}
+		return &setDataRequest{}
 	case opSetWatches:
 		return &setWatchesRequest{}
 	case opSetWatches2:
 		return &setWatches2Request{}
 	case opAddWatch:
 		return &addWatchRequest{}
+	case opRemoveWatches:
+		return &removeWatchesRequest{}
 	case opSync:
 		return &syncRequest{}
 	case opSetAuth:
 		return &setAuthRequest{}
 	case opCheck:
-		return &CheckVersionRequest{}
+		return &checkVersionRequest{}
 	case opMulti:
 		return &multiRequest{}
 	case opReconfig:

--- a/structs_test.go
+++ b/structs_test.go
@@ -14,9 +14,9 @@ func TestEncodeDecodePacket(t *testing.T) {
 	encodeDecodeTest(t, &getChildrenResponse{[]string{"foo", "bar"}})
 	encodeDecodeTest(t, &pathWatchRequest{"path", true})
 	encodeDecodeTest(t, &pathWatchRequest{"path", false})
-	encodeDecodeTest(t, &CheckVersionRequest{"/", -1})
+	encodeDecodeTest(t, &checkVersionRequest{"/", -1})
 	encodeDecodeTest(t, &reconfigRequest{nil, nil, nil, -1})
-	encodeDecodeTest(t, &multiRequest{Ops: []multiRequestOp{{multiHeader{opCheck, false, -1}, &CheckVersionRequest{"/", -1}}}})
+	encodeDecodeTest(t, &multiRequest{Ops: []multiRequestOp{{multiHeader{opCheck, false, -1}, &checkVersionRequest{"/", -1}}}})
 }
 
 func TestRequestStructForOp(t *testing.T) {

--- a/zk_test.go
+++ b/zk_test.go
@@ -381,8 +381,8 @@ func TestMulti(t *testing.T) {
 		t.Fatalf("Delete returned error: %+v", err)
 	}
 	ops := []interface{}{
-		&CreateRequest{Path: path, Data: []byte{1, 2, 3, 4}, Acl: WorldACL(PermAll)},
-		&SetDataRequest{Path: path, Data: []byte{1, 2, 3, 4}, Version: -1},
+		&createRequest{Path: path, Data: []byte{1, 2, 3, 4}, Acl: WorldACL(PermAll)},
+		&setDataRequest{Path: path, Data: []byte{1, 2, 3, 4}, Version: -1},
 	}
 	if res, err := zk.Multi(ops...); err != nil {
 		t.Fatalf("Multi returned error: %+v", err)
@@ -479,8 +479,8 @@ func TestMultiFailures(t *testing.T) {
 	}
 
 	ops := []interface{}{
-		&CreateRequest{Path: firstPath, Data: []byte{1, 2}, Acl: WorldACL(PermAll)},
-		&CreateRequest{Path: secondPath, Data: []byte{3, 4}, Acl: WorldACL(PermAll)},
+		&createRequest{Path: firstPath, Data: []byte{1, 2}, Acl: WorldACL(PermAll)},
+		&createRequest{Path: secondPath, Data: []byte{3, 4}, Acl: WorldACL(PermAll)},
 	}
 	res, err := zk.Multi(ops...)
 	if err != ErrNodeExists {


### PR DESCRIPTION
This PR introduces a new method, `RemoveWatch`, that can de-register any watcher associated with the given event channel. This works for all types of watches - persistent and non-persistent. 

Secondly, this PR increases the buffer size of watcher event channels to mitigate the impact of slow consumers. 

Lastly, this PR normalizes the names of some request/response structs to ensure consistency - they should all have lower-case first char to ensure package-private scope.