### PR TITLE
Revert rename of some request structs

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1133,7 +1133,7 @@ func (c *Conn) RemoveWatch(ech <-chan Event) error {
 	if remaining == 0 {
 		// No more watchers remain for the watchPathType, so we can remove the watch from the server.
 		res := &removeWatchesResponse{}
-		_, err := c.request(opRemoveWatches, &removeWatchesRequest{Path: wpt.path, Type: wpt.wType.WatcherType()}, res, nil)
+		_, err := c.request(opRemoveWatches, &RemoveWatchesRequest{Path: wpt.path, Type: wpt.wType.WatcherType()}, res, nil)
 		if err != nil {
 			return err
 		}
@@ -1215,7 +1215,7 @@ func (c *Conn) Set(path string, data []byte, version int32) (*Stat, error) {
 	}
 
 	res := &setDataResponse{}
-	_, err := c.request(opSetData, &setDataRequest{path, data, version}, res, nil)
+	_, err := c.request(opSetData, &SetDataRequest{path, data, version}, res, nil)
 	if err == ErrConnectionClosed {
 		return nil, err
 	}
@@ -1232,7 +1232,7 @@ func (c *Conn) Create(path string, data []byte, flags int32, acl []ACL) (string,
 	}
 
 	res := &createResponse{}
-	_, err := c.request(opCreate, &createRequest{path, data, acl, flags}, res, nil)
+	_, err := c.request(opCreate, &CreateRequest{path, data, acl, flags}, res, nil)
 	if err == ErrConnectionClosed {
 		return "", err
 	}
@@ -1249,7 +1249,7 @@ func (c *Conn) CreateContainer(path string, data []byte, flags int32, acl []ACL)
 	}
 
 	res := &createResponse{}
-	_, err := c.request(opCreateContainer, &createContainerRequest{path, data, acl, flags}, res, nil)
+	_, err := c.request(opCreateContainer, &CreateContainerRequest{path, data, acl, flags}, res, nil)
 	return res.Path, err
 }
 
@@ -1322,7 +1322,7 @@ func (c *Conn) Delete(path string, version int32) error {
 		return err
 	}
 
-	_, err := c.request(opDelete, &deleteRequest{path, version}, &deleteResponse{}, nil)
+	_, err := c.request(opDelete, &DeleteRequest{path, version}, &deleteResponse{}, nil)
 	return err
 }
 
@@ -1423,8 +1423,8 @@ type MultiResponse struct {
 }
 
 // Multi executes multiple ZooKeeper operations or none of them. The provided
-// ops must be one of *createRequest, *deleteRequest, *setDataRequest, or
-// *checkVersionRequest.
+// ops must be one of *CreateRequest, *DeleteRequest, *SetDataRequest, or
+// *CheckVersionRequest.
 func (c *Conn) Multi(ops ...interface{}) ([]MultiResponse, error) {
 	req := &multiRequest{
 		Ops:        make([]multiRequestOp, 0, len(ops)),
@@ -1433,13 +1433,13 @@ func (c *Conn) Multi(ops ...interface{}) ([]MultiResponse, error) {
 	for _, op := range ops {
 		var opCode int32
 		switch op.(type) {
-		case *createRequest:
+		case *CreateRequest:
 			opCode = opCreate
-		case *setDataRequest:
+		case *SetDataRequest:
 			opCode = opSetData
-		case *deleteRequest:
+		case *DeleteRequest:
 			opCode = opDelete
-		case *checkVersionRequest:
+		case *CheckVersionRequest:
 			opCode = opCheck
 		default:
 			return nil, fmt.Errorf("unknown operation type %T", op)

--- a/structs.go
+++ b/structs.go
@@ -140,7 +140,7 @@ type statResponse struct {
 
 //
 
-type checkVersionRequest PathVersionRequest
+type CheckVersionRequest PathVersionRequest
 type closeRequest struct{}
 type closeResponse struct{}
 
@@ -159,14 +159,14 @@ type connectResponse struct {
 	Passwd          []byte
 }
 
-type createRequest struct {
+type CreateRequest struct {
 	Path  string
 	Data  []byte
 	Acl   []ACL
 	Flags int32
 }
 
-type createContainerRequest createRequest
+type CreateContainerRequest CreateRequest
 
 type CreateTTLRequest struct {
 	Path  string
@@ -177,7 +177,7 @@ type CreateTTLRequest struct {
 }
 
 type createResponse pathResponse
-type deleteRequest PathVersionRequest
+type DeleteRequest PathVersionRequest
 type deleteResponse struct{}
 
 type errorResponse struct {
@@ -241,7 +241,7 @@ type addWatchRequest struct {
 
 type addWatchResponse struct{}
 
-type setDataRequest struct {
+type SetDataRequest struct {
 	Path    string
 	Data    []byte
 	Version int32
@@ -282,7 +282,7 @@ type setWatches2Request struct {
 
 type setWatches2Response struct{}
 
-type removeWatchesRequest struct {
+type RemoveWatchesRequest struct {
 	Path string
 	Type WatcherType
 }
@@ -624,13 +624,13 @@ func requestStructForOp(op int32) interface{} {
 	case opClose:
 		return &closeRequest{}
 	case opCreate:
-		return &createRequest{}
+		return &CreateRequest{}
 	case opCreateContainer:
-		return &createContainerRequest{}
+		return &CreateContainerRequest{}
 	case opCreateTTL:
 		return &CreateTTLRequest{}
 	case opDelete:
-		return &deleteRequest{}
+		return &DeleteRequest{}
 	case opExists:
 		return &existsRequest{}
 	case opGetAcl:
@@ -646,7 +646,7 @@ func requestStructForOp(op int32) interface{} {
 	case opSetAcl:
 		return &setAclRequest{}
 	case opSetData:
-		return &setDataRequest{}
+		return &SetDataRequest{}
 	case opSetWatches:
 		return &setWatchesRequest{}
 	case opSetWatches2:
@@ -654,13 +654,13 @@ func requestStructForOp(op int32) interface{} {
 	case opAddWatch:
 		return &addWatchRequest{}
 	case opRemoveWatches:
-		return &removeWatchesRequest{}
+		return &RemoveWatchesRequest{}
 	case opSync:
 		return &syncRequest{}
 	case opSetAuth:
 		return &setAuthRequest{}
 	case opCheck:
-		return &checkVersionRequest{}
+		return &CheckVersionRequest{}
 	case opMulti:
 		return &multiRequest{}
 	case opReconfig:

--- a/structs_test.go
+++ b/structs_test.go
@@ -14,9 +14,9 @@ func TestEncodeDecodePacket(t *testing.T) {
 	encodeDecodeTest(t, &getChildrenResponse{[]string{"foo", "bar"}})
 	encodeDecodeTest(t, &pathWatchRequest{"path", true})
 	encodeDecodeTest(t, &pathWatchRequest{"path", false})
-	encodeDecodeTest(t, &checkVersionRequest{"/", -1})
+	encodeDecodeTest(t, &CheckVersionRequest{"/", -1})
 	encodeDecodeTest(t, &reconfigRequest{nil, nil, nil, -1})
-	encodeDecodeTest(t, &multiRequest{Ops: []multiRequestOp{{multiHeader{opCheck, false, -1}, &checkVersionRequest{"/", -1}}}})
+	encodeDecodeTest(t, &multiRequest{Ops: []multiRequestOp{{multiHeader{opCheck, false, -1}, &CheckVersionRequest{"/", -1}}}})
 }
 
 func TestRequestStructForOp(t *testing.T) {

--- a/zk_test.go
+++ b/zk_test.go
@@ -381,8 +381,8 @@ func TestMulti(t *testing.T) {
 		t.Fatalf("Delete returned error: %+v", err)
 	}
 	ops := []interface{}{
-		&createRequest{Path: path, Data: []byte{1, 2, 3, 4}, Acl: WorldACL(PermAll)},
-		&setDataRequest{Path: path, Data: []byte{1, 2, 3, 4}, Version: -1},
+		&CreateRequest{Path: path, Data: []byte{1, 2, 3, 4}, Acl: WorldACL(PermAll)},
+		&SetDataRequest{Path: path, Data: []byte{1, 2, 3, 4}, Version: -1},
 	}
 	if res, err := zk.Multi(ops...); err != nil {
 		t.Fatalf("Multi returned error: %+v", err)
@@ -479,8 +479,8 @@ func TestMultiFailures(t *testing.T) {
 	}
 
 	ops := []interface{}{
-		&createRequest{Path: firstPath, Data: []byte{1, 2}, Acl: WorldACL(PermAll)},
-		&createRequest{Path: secondPath, Data: []byte{3, 4}, Acl: WorldACL(PermAll)},
+		&CreateRequest{Path: firstPath, Data: []byte{1, 2}, Acl: WorldACL(PermAll)},
+		&CreateRequest{Path: secondPath, Data: []byte{3, 4}, Acl: WorldACL(PermAll)},
 	}
 	res, err := zk.Multi(ops...)
 	if err != ErrNodeExists {


### PR DESCRIPTION
Reverting some struct renames I made back in https://github.com/Shopify/zk/pull/6. As it turns out, some of these were actually intended to be referenced outside the zk package for use with the `Multi` operation. These renames break go-leaderelection. 😢 