### PR TITLE
Add RefreshDNSHostProvider

### DIFF
--- a/refreshdnshostprovider.go
+++ b/refreshdnshostprovider.go
@@ -1,0 +1,59 @@
+package zk
+
+import "sync"
+
+// RefreshDNSHostProvider is a wrapper around DNSHostProvider
+// that will re-resolve server addresses:
+//   - everytime the list of server IPs has been fully tried
+//   - everytime we ask for a server IP for a reconnection
+type RefreshDNSHostProvider struct {
+	DNSHostProvider
+
+	mu              sync.Mutex
+	connected       bool
+	serverAddresses []string
+}
+
+func NewRefreshDNSHostProvider() HostProvider {
+	return &RefreshDNSHostProvider{}
+}
+
+func (hp *RefreshDNSHostProvider) Init(servers []string) error {
+	hp.mu.Lock()
+	defer hp.mu.Unlock()
+
+	hp.serverAddresses = servers
+	return hp.DNSHostProvider.Init(hp.serverAddresses)
+}
+
+func (hp *RefreshDNSHostProvider) Next() (server string, retryStart bool) {
+	hp.mu.Lock()
+	defer hp.mu.Unlock()
+
+	// we were connected and we're not anymore, refresh the list of servers
+	if hp.connected {
+		hp.refresh()
+	}
+
+	server, retryStart = hp.DNSHostProvider.Next()
+	if retryStart {
+		hp.refresh()
+	}
+	return
+}
+
+// Connected notifies the HostProvider of a successful connection.
+func (hp *RefreshDNSHostProvider) Connected() {
+	hp.mu.Lock()
+	defer hp.mu.Unlock()
+
+	hp.connected = true
+}
+
+// backgroundRefresh is a refresh() but logs the error and does not return it.
+func (hp *RefreshDNSHostProvider) refresh() {
+	hp.connected = false
+	if err := hp.DNSHostProvider.Init(hp.serverAddresses); err != nil {
+		DefaultLogger.Printf("failed to refresh serverAddresses: %v", err)
+	}
+}

--- a/refreshdnshostprovider_test.go
+++ b/refreshdnshostprovider_test.go
@@ -1,0 +1,58 @@
+package zk
+
+import (
+	"testing"
+)
+
+func TestRefreshDNSHostProviderReconnection(t *testing.T) {
+	hp := refreshDNSHostProvider(t)
+
+	hp.Connected()
+
+	hp.DNSHostProvider.lookupHost = func(host string) ([]string, error) {
+		return []string{"10.0.0.1"}, nil
+	}
+
+	ip, _ := hp.Next()
+	if ip != "10.0.0.1:2181" {
+		t.Fatalf("expected ip to be 10.0.0.1, got %v", ip)
+	}
+}
+
+func TestRefreshDNSHostProviderRetryStart(t *testing.T) {
+	hp := refreshDNSHostProvider(t)
+
+	hp.DNSHostProvider.lookupHost = func(host string) ([]string, error) {
+		return []string{"10.0.0.1"}, nil
+	}
+
+	for {
+		if _, retryStart := hp.Next(); retryStart {
+			break
+		}
+	}
+
+	ip, _ := hp.Next()
+	if ip != "10.0.0.1:2181" {
+		t.Fatalf("expected ip to be 10.0.0.1, got %v", ip)
+	}
+}
+
+func refreshDNSHostProvider(t *testing.T) *RefreshDNSHostProvider {
+	t.Helper()
+	hp := &RefreshDNSHostProvider{}
+
+	hp.DNSHostProvider.lookupHost = func(host string) ([]string, error) {
+		return []string{"192.0.2.1", "192.0.2.2", "192.0.2.3"}, nil
+	}
+
+	if err := hp.Init([]string{"foo.local:2181"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if hp.Len() != 3 {
+		t.Fatalf("unexpected length: %d", hp.Len())
+	}
+
+	return hp
+}


### PR DESCRIPTION
RefreshDNSHostProvider is a wrapper around DNSHostProvider
that will re-resolve server addresses:
  - everytime the list of server IPs has been fully tried
  - everytime we ask for a server IP for a reconnection

Rel: https://github.com/Shopify/network-platform/issues/870