### PR TITLE
Add a WalkLeavesParallel for CachedLeavesWalker init

### DIFF
--- a/cached_leaves_walker.go
+++ b/cached_leaves_walker.go
@@ -37,7 +37,7 @@ func NewCachedLeavesWalker(conn *Conn, path string) (*CachedLeavesWalker, error)
 	}
 
 	go w.eventLoop()
-	if err = w.conn.WalkLeaves(path, func(p string, stat *Stat) error {
+	if err = w.conn.WalkLeavesParallel(path, func(p string, stat *Stat) error {
 		w.lock.Lock()
 		w.tree.ensurePathPresent(p)
 		w.lock.Unlock()
@@ -101,7 +101,7 @@ func (w *CachedLeavesWalker) walkLeaves(p string, tree cachedLeavesTreeNode, vis
 	return visitor(p)
 }
 
-//cachedLeavesTreeNode represent an in memory znode equivalent.
+// cachedLeavesTreeNode represent an in memory znode equivalent.
 type cachedLeavesTreeNode map[string]cachedLeavesTreeNode
 
 // ensurePathPresent will make sure we have the proper in-memory tree for a given path.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/Shopify/zk
 
 go 1.18
+
+require golang.org/x/sync v0.0.0-20220907140024-f12130a52804 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.0.0-20220907140024-f12130a52804 h1:0SH2R3f1b1VmIMG7BXbEZCBUu2dKmHschSmjqGUrW8A=
+golang.org/x/sync v0.0.0-20220907140024-f12130a52804/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
The `CachedLeavesWalker` can sometime take long to initialize if the latency between the client & zookeeper is "high".
Only 100ms and a few thousand keys can result in minutes to load.

With this parallel walk, it falls down to seconds.