### PR TITLE
Add `TreeWalker` to handle all tree-visiting needs.

### DIFF
--- a/_examples/tree_walker.go
+++ b/_examples/tree_walker.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/Shopify/zk"
+)
+
+func main() {
+	c, events, err := zk.Connect([]string{"127.0.0.1:2181", "127.0.0.1:2182", "127.0.0.1:2183"}, time.Second) //*10)
+	if err != nil {
+		panic(err)
+	}
+	go func() {
+		for e := range events {
+			log.Printf("SessionEvent: %+v", e)
+		}
+		log.Printf("SessionEvent closed")
+	}()
+
+	// Walk breath-first.
+	err = c.TreeWalker("/foo").
+		BreadthFirst().
+		Walk(func(p string, stat *zk.Stat) error {
+			log.Printf("Got %s", p)
+			return nil
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	// Walk depth-first and visit leaves only.
+	err = c.TreeWalker("/foo").
+		DepthFirst().
+		LeavesOnly().
+		Walk(func(p string, stat *zk.Stat) error {
+			log.Printf("Got %s", p)
+			return nil
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	// Walk breath-first with parallel traversal and receive events by channel.
+	ch := c.TreeWalker("/foo").
+		BreadthFirstParallel().
+		WalkChan(8) // You can tune the buffer size.
+	for e := range ch {
+		if e.Err != nil {
+			panic(e.Err)
+		}
+		log.Printf("Got %s", e.Path)
+	}
+}

--- a/tree_walker.go
+++ b/tree_walker.go
@@ -1,0 +1,293 @@
+package zk
+
+import (
+	"context"
+	gopath "path"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// ChildrenFunc is a function that returns the children of a node.
+type ChildrenFunc func(ctx context.Context, path string) ([]string, *Stat, error)
+
+// VisitorFunc is a function that is called for each node visited.
+type VisitorFunc func(path string, stat *Stat) error
+
+// VisitorCtxFunc is like VisitorFunc, but it takes a context.
+type VisitorCtxFunc func(ctx context.Context, path string, stat *Stat) error
+
+// VisitEvent is the event that is sent to the channel returned by various walk functions.
+// If Err is not nil, it indicates that an error occurred while walking the tree.
+type VisitEvent struct {
+	Path string
+	Stat *Stat
+	Err  error
+}
+
+// InitTreeWalker initializes a TreeWalker with the given fetcher function and root path.
+func InitTreeWalker(fetcher ChildrenFunc, path string) TreeWalker {
+	return TreeWalker{
+		fetcher:     fetcher,
+		path:        path,
+		includeRoot: true,
+		walker:      walkBreadthFirst,
+		decorator:   func(v VisitorCtxFunc) VisitorCtxFunc { return v }, // Identity.
+	}
+}
+
+// TreeWalker provides flexible traversal of a tree of nodes rooted at a specific path.
+// The traversal can be configured by calling one of DepthFirst, DepthFirstParallel, BreadthFirst, or BreadthFirstParallel.
+// By default, the walker will visit the root node, but this can be changed by calling IncludeRoot.
+// The walker can also be configured to only visit leaf nodes by calling LeavesOnly.
+type TreeWalker struct {
+	fetcher     ChildrenFunc
+	path        string
+	includeRoot bool
+	walker      walkFunc
+	decorator   visitorDecoratorFunc
+}
+
+// DepthFirst configures the walker for a sequential traversal in depth-first order.
+func (w TreeWalker) DepthFirst() TreeWalker {
+	return TreeWalker{
+		fetcher:     w.fetcher,
+		path:        w.path,
+		includeRoot: w.includeRoot,
+		walker:      walkDepthFirst,
+		decorator:   w.decorator,
+	}
+}
+
+// DepthFirstParallel configures the walker a parallel traversal in depth-first order.
+// Note: Parallel traversal will break strict depth-first ordering, since children are visited in parallel.
+func (w TreeWalker) DepthFirstParallel() TreeWalker {
+	return TreeWalker{
+		fetcher:     w.fetcher,
+		path:        w.path,
+		includeRoot: w.includeRoot,
+		walker:      walkDepthFirstParallel,
+		decorator:   w.decorator,
+	}
+}
+
+// BreadthFirst configures the walker for a sequential traversal in breadth-first order.
+func (w TreeWalker) BreadthFirst() TreeWalker {
+	return TreeWalker{
+		fetcher:     w.fetcher,
+		path:        w.path,
+		includeRoot: w.includeRoot,
+		walker:      walkBreadthFirst,
+		decorator:   w.decorator,
+	}
+}
+
+// BreadthFirstParallel configures the walker for a parallel traversal in breadth-first order.
+// Note: Parallel traversal will break strict breadth-first ordering, since children are visited in parallel.
+func (w TreeWalker) BreadthFirstParallel() TreeWalker {
+	return TreeWalker{
+		fetcher:     w.fetcher,
+		path:        w.path,
+		includeRoot: w.includeRoot,
+		walker:      walkBreadthFirstParallel,
+		decorator:   w.decorator,
+	}
+}
+
+// IncludeRoot configures the walker to visit the root node or not.
+func (w TreeWalker) IncludeRoot(included bool) TreeWalker {
+	return TreeWalker{
+		fetcher:     w.fetcher,
+		path:        w.path,
+		includeRoot: included,
+		walker:      w.walker,
+		decorator:   w.decorator,
+	}
+}
+
+// LeavesOnly configures the walker to only visit leaf nodes.
+func (w TreeWalker) LeavesOnly() TreeWalker {
+	return TreeWalker{
+		fetcher:     w.fetcher,
+		path:        w.path,
+		includeRoot: w.includeRoot,
+		walker:      w.walker,
+		decorator: func(v VisitorCtxFunc) VisitorCtxFunc {
+			// Only call the original visitor if the node has no children.
+			return func(ctx context.Context, path string, stat *Stat) error {
+				if stat.NumChildren == 0 {
+					return v(ctx, path, stat)
+				}
+				return nil
+			}
+		},
+	}
+}
+
+// Walk begins traversing the tree and calls the visitor function for each node visited.
+// Note: The DepthFirstParallel and BreadthFirstParallel traversals require the visitor function to be thread-safe.
+func (w TreeWalker) Walk(visitor VisitorFunc) error {
+	// Adapt VisitorFunc to VisitorCtxFunc.
+	vc := func(ctx context.Context, path string, stat *Stat) error {
+		return visitor(path, stat)
+	}
+	return w.WalkCtx(context.Background(), vc)
+}
+
+// WalkCtx is like Walk, but takes a context that can be used to cancel the walk.
+func (w TreeWalker) WalkCtx(ctx context.Context, visitor VisitorCtxFunc) error {
+	visitor = w.decorator(visitor) // Apply decorator.
+	return w.walker(ctx, w.fetcher, w.path, w.includeRoot, visitor)
+}
+
+// WalkChan begins traversing the tree and sends the results to the returned channel.
+// The channel will be buffered with the given size.
+// The channel is closed when the traversal is complete.
+// If an error occurs, an error event will be sent to the channel before it is closed.
+func (w TreeWalker) WalkChan(bufferSize int) <-chan VisitEvent {
+	return w.WalkChanCtx(context.Background(), bufferSize)
+}
+
+// WalkChanCtx is like WalkChan, but it takes a context that can be used to cancel the walk.
+func (w TreeWalker) WalkChanCtx(ctx context.Context, bufferSize int) <-chan VisitEvent {
+	ch := make(chan VisitEvent, bufferSize)
+	visitor := func(ctx context.Context, path string, stat *Stat) error {
+		ch <- VisitEvent{Path: path, Stat: stat}
+		return nil
+	}
+	go func() {
+		defer close(ch)
+		if err := w.WalkCtx(ctx, visitor); err != nil {
+			ch <- VisitEvent{Err: err}
+		}
+	}()
+	return ch
+}
+
+// walkFunc is a function that implements a recursive tree traversal.
+type walkFunc func(ctx context.Context, fetcher ChildrenFunc, path string, includeSelf bool, visitor VisitorCtxFunc) error
+
+// visitorDecoratorFunc is a function that decorates a visitor function.
+type visitorDecoratorFunc func(v VisitorCtxFunc) VisitorCtxFunc
+
+// walkDepthFirst walks the tree rooted at path in depth-first order.
+func walkDepthFirst(ctx context.Context, fetcher ChildrenFunc, path string, includeSelf bool, visitor VisitorCtxFunc) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	children, stat, err := fetcher(ctx, path)
+	if err != nil {
+		if err == ErrNoNode {
+			return nil // Ignore ErrNoNode.
+		}
+		return err
+	}
+
+	for _, child := range children {
+		childPath := gopath.Join(path, child)
+		if err = walkDepthFirst(ctx, fetcher, childPath, true, visitor); err != nil {
+			return err
+		}
+	}
+
+	if includeSelf {
+		if err = visitor(ctx, path, stat); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// walkDepthFirstParallel walks the tree rooted at path in depth-first order, but in parallel.
+func walkDepthFirstParallel(ctx context.Context, fetcher ChildrenFunc, path string, includeSelf bool, visitor VisitorCtxFunc) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	children, stat, err := fetcher(ctx, path)
+	if err != nil {
+		if err == ErrNoNode {
+			return nil // Ignore ErrNoNode.
+		}
+		return err
+	}
+
+	eg, egctx := errgroup.WithContext(ctx)
+	for _, child := range children {
+		childPath := gopath.Join(path, child)
+		eg.Go(func() error {
+			return walkDepthFirstParallel(egctx, fetcher, childPath, true, visitor)
+		})
+	}
+
+	if includeSelf {
+		eg.Go(func() error {
+			return visitor(egctx, path, stat)
+		})
+	}
+
+	return eg.Wait()
+}
+
+// walkBreadthFirst walks the tree rooted at path in breadth-first order.
+func walkBreadthFirst(ctx context.Context, fetcher ChildrenFunc, path string, includeSelf bool, visitor VisitorCtxFunc) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	children, stat, err := fetcher(ctx, path)
+	if err != nil {
+		if err == ErrNoNode {
+			return nil // Ignore ErrNoNode.
+		}
+		return err
+	}
+
+	if includeSelf {
+		if err = visitor(ctx, path, stat); err != nil {
+			return err
+		}
+	}
+
+	for _, child := range children {
+		childPath := gopath.Join(path, child)
+		if err = walkBreadthFirst(ctx, fetcher, childPath, true, visitor); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// walkBreadthFirstParallel walks the tree rooted at path in breadth-first order, but in parallel.
+func walkBreadthFirstParallel(ctx context.Context, fetcher ChildrenFunc, path string, includeSelf bool, visitor VisitorCtxFunc) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	children, stat, err := fetcher(ctx, path)
+	if err != nil {
+		if err == ErrNoNode {
+			return nil // Ignore ErrNoNode.
+		}
+		return err
+	}
+
+	eg, egctx := errgroup.WithContext(ctx)
+
+	if includeSelf {
+		eg.Go(func() error {
+			return visitor(egctx, path, stat)
+		})
+	}
+
+	for _, child := range children {
+		childPath := gopath.Join(path, child)
+		eg.Go(func() error {
+			return walkBreadthFirstParallel(egctx, fetcher, childPath, true, visitor)
+		})
+	}
+
+	return eg.Wait()
+}

--- a/tree_walker_test.go
+++ b/tree_walker_test.go
@@ -1,0 +1,249 @@
+package zk
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestTreeWalker(t *testing.T) {
+	testCases := []struct {
+		name        string
+		setupWalker func(w TreeWalker) TreeWalker
+		expected    []string
+		ignoreOrder bool // For parallel walks which are never consistent.
+	}{
+		{
+			name: "DepthFirst_IncludeRoot",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.DepthFirst().IncludeRoot(true)
+			},
+			expected: []string{
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c/d",
+				"/gozk-test-walker/a/c",
+				"/gozk-test-walker/a",
+				"/gozk-test-walker",
+			},
+		},
+		{
+			name: "DepthFirstParallel_IncludeRoot",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.DepthFirstParallel().IncludeRoot(true)
+			},
+			expected: []string{
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c/d",
+				"/gozk-test-walker/a/c",
+				"/gozk-test-walker/a",
+				"/gozk-test-walker",
+			},
+			ignoreOrder: true, // Parallel traversal causes non-deterministic ordering.
+		},
+		{
+			name: "BreadthFirst_IncludeRoot",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.BreadthFirst().IncludeRoot(true)
+			},
+			expected: []string{
+				"/gozk-test-walker",
+				"/gozk-test-walker/a",
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c",
+				"/gozk-test-walker/a/c/d",
+			},
+		},
+		{
+			name: "BreadthFirstParallel_IncludeRoot",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.BreadthFirstParallel().IncludeRoot(true)
+			},
+			expected: []string{
+				"/gozk-test-walker",
+				"/gozk-test-walker/a",
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c",
+				"/gozk-test-walker/a/c/d",
+			},
+			ignoreOrder: true, // Parallel traversal causes non-deterministic ordering.
+		},
+		{
+			name: "DepthFirst_ExcludeRoot",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.DepthFirst().IncludeRoot(false)
+			},
+			expected: []string{
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c/d",
+				"/gozk-test-walker/a/c",
+				"/gozk-test-walker/a",
+			},
+		},
+		{
+			name: "DepthFirstParallel_ExcludeRoot",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.DepthFirstParallel().IncludeRoot(false)
+			},
+			expected: []string{
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c/d",
+				"/gozk-test-walker/a/c",
+				"/gozk-test-walker/a",
+			},
+			ignoreOrder: true, // Parallel traversal causes non-deterministic ordering.
+		},
+		{
+			name: "BreadthFirst_ExcludeRoot",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.BreadthFirst().IncludeRoot(false)
+			},
+			expected: []string{
+				"/gozk-test-walker/a",
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c",
+				"/gozk-test-walker/a/c/d",
+			},
+		},
+		{
+			name: "BreadthFirstParallel_ExcludeRoot",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.BreadthFirstParallel().IncludeRoot(false)
+			},
+			expected: []string{
+				"/gozk-test-walker/a",
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c",
+				"/gozk-test-walker/a/c/d",
+			},
+			ignoreOrder: true, // Parallel traversal causes non-deterministic ordering.
+		},
+		{
+			name: "DepthFirst_LeavesOnly",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.DepthFirst().LeavesOnly()
+			},
+			expected: []string{
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c/d",
+			},
+		},
+		{
+			name: "DepthFirstParallel_LeavesOnly",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.DepthFirstParallel().LeavesOnly()
+			},
+			expected: []string{
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c/d",
+			},
+			ignoreOrder: true, // Parallel traversal causes non-deterministic ordering.
+		},
+		{
+			name: "BreadthFirst_LeavesOnly",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.BreadthFirst().LeavesOnly()
+			},
+			expected: []string{
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c/d",
+			},
+		},
+		{
+			name: "BreadthFirstParallel_LeavesOnly",
+			setupWalker: func(w TreeWalker) TreeWalker {
+				return w.BreadthFirstParallel().LeavesOnly()
+			},
+			expected: []string{
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c/d",
+			},
+			ignoreOrder: true, // Parallel traversal causes non-deterministic ordering.
+		},
+	}
+
+	expectVisitedExact := func(t *testing.T, expected []string, visited []string) {
+		if !reflect.DeepEqual(expected, visited) {
+			t.Fatalf("%s saw unexpected paths:\n Expected: %+v\n Got:      %+v",
+				t.Name(), expected, visited)
+		}
+	}
+
+	expectVisitedUnordered := func(t *testing.T, expected []string, visited []string) {
+		expectedSet := make(map[string]struct{})
+		visitedSet := make(map[string]struct{})
+		for _, p := range expected {
+			expectedSet[p] = struct{}{}
+		}
+		for _, p := range visited {
+			visitedSet[p] = struct{}{}
+		}
+		if !reflect.DeepEqual(expectedSet, visitedSet) {
+			t.Fatalf("%s saw unexpected paths:\n Expected: %+v\n Got:      %+v",
+				t.Name(), expected, visited)
+		}
+	}
+
+	WithTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "}, func(t *testing.T, tc *TestCluster) {
+		WithConnectAll(t, tc, func(t *testing.T, c *Conn, _ <-chan Event) {
+			paths := []string{
+				"/gozk-test-walker",
+				"/gozk-test-walker/a",
+				"/gozk-test-walker/a/b",
+				"/gozk-test-walker/a/c",
+				"/gozk-test-walker/a/c/d",
+			}
+			for _, p := range paths {
+				if path, err := c.Create(p, []byte{1, 2, 3, 4}, 0, WorldACL(PermAll)); err != nil {
+					t.Fatalf("Create returned error: %+v", err)
+				} else if path != p {
+					t.Fatalf("Create returned different path '%s' != '%s'", path, p)
+				}
+			}
+
+			for _, testCase := range testCases {
+				// Test the Walk with visitor.
+				t.Run(testCase.name+"_Walk", func(t *testing.T) {
+					var visited []string
+					l := sync.Mutex{} // Protects visited from concurrent access.
+					w := InitTreeWalker(c.ChildrenCtx, "/gozk-test-walker")
+					err := testCase.setupWalker(w).Walk(func(path string, _ *Stat) error {
+						l.Lock()
+						defer l.Unlock()
+						visited = append(visited, path)
+						return nil
+					})
+					if err != nil {
+						t.Fatalf("%s Walk returned an error: %+v", testCase.name, err)
+					}
+
+					l.Lock()
+					defer l.Unlock()
+					if testCase.ignoreOrder {
+						expectVisitedUnordered(t, testCase.expected, visited)
+					} else {
+						expectVisitedExact(t, testCase.expected, visited)
+					}
+				})
+
+				// Test the walk with channel events.
+				t.Run(testCase.name+"_WalkChan", func(t *testing.T) {
+					var visited []string
+					w := InitTreeWalker(c.ChildrenCtx, "/gozk-test-walker")
+					ch := testCase.setupWalker(w).WalkChan(1)
+					for e := range ch {
+						if e.Err != nil {
+							t.Fatalf("%s WalkChan returned an error: %+v", testCase.name, e.Err)
+						}
+						visited = append(visited, e.Path)
+					}
+
+					if testCase.ignoreOrder {
+						expectVisitedUnordered(t, testCase.expected, visited)
+					} else {
+						expectVisitedExact(t, testCase.expected, visited)
+					}
+				})
+			}
+		})
+	})
+}

--- a/zk_test.go
+++ b/zk_test.go
@@ -1701,65 +1701,6 @@ func TestWalkLeaves(t *testing.T) {
 	})
 }
 
-func TestWalkLeavesParallel(t *testing.T) {
-	t.Parallel()
-
-	WithTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "}, func(t *testing.T, tc *TestCluster) {
-		WithConnectAll(t, tc, func(t *testing.T, c *Conn, _ <-chan Event) {
-			paths := []string{
-				"/gozk-test-walkleavesparallel",
-				"/gozk-test-walkleavesparallel/a",
-				"/gozk-test-walkleavesparallel/a/b",
-				"/gozk-test-walkleavesparallel/a/c",
-				"/gozk-test-walkleavesparallel/a/c/d",
-			}
-			for _, p := range paths {
-				if path, err := c.Create(p, []byte{1, 2, 3, 4}, 0, WorldACL(PermAll)); err != nil {
-					t.Fatalf("Create returned error: %+v", err)
-				} else if path != p {
-					t.Fatalf("Create returned different path '%s' != '%s'", path, p)
-				}
-			}
-
-			t.Run("Found", func(t *testing.T) {
-				var visited []string
-
-				err := c.WalkLeaves("/gozk-test-walkleavesparallel/a", func(p string, stat *Stat) error {
-					visited = append(visited, p)
-					return nil
-				})
-				if err != nil {
-					t.Fatalf("WalkLeaves returned error: %+v", err)
-				}
-
-				expected := []string{
-					"/gozk-test-walkleavesparallel/a/b",
-					"/gozk-test-walkleavesparallel/a/c/d",
-				}
-				if !reflect.DeepEqual(visited, expected) {
-					t.Fatalf("WalkLeaves returned the wrong leaves, exptected %+v, got %+v", expected, visited)
-				}
-			})
-
-			t.Run("Not Found", func(t *testing.T) {
-				var visited []string
-
-				err := c.WalkLeaves("/gozk-test-walkleavesparallel/e", func(p string, stat *Stat) error {
-					visited = append(visited, p)
-					return nil
-				})
-				if err != nil {
-					t.Fatalf("WalkLeaves returned error: %+v", err)
-				}
-
-				if len(visited) != 0 {
-					t.Fatalf("WalkLeaves returned the wrong leaves, exptected [], got %+v", visited)
-				}
-			})
-		})
-	})
-}
-
 func TestCachedLeavesWalker(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Added a new helper, `TreeWalker`, that can handle visiting tree nodes from either a direct connection or a cache (future PR).   You need only provide a function satisfying `type ChildrenFunc func(ctx context.Context, path string) ([]string, *Stat, error)` for the `TreeWalker` to function.

The `TreeWalker` provides the following features:

* Breadth-first and depth-first ordering
* Sequential and parallel traversal
* Optionally filtering on leaves-only
* Receive nodes with either visitor callback or async event channel (especially useful with parallel traversal).
