### PR TITLE
TreeCache options: include data, absolute paths, custom logger

### DIFF
--- a/tree_cache_test.go
+++ b/tree_cache_test.go
@@ -2,43 +2,44 @@ package zk
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 )
 
 func TestTreeCache_ConsistentAfterInitialSync(t *testing.T) {
 	initialNodes := []struct {
-		path        string
+		realPath    string
 		cachePath   string
 		data        string
 		numChildren int32
 	}{
 		{
-			path:        "/test-tree-cache",
+			realPath:    "/test-tree-cache",
 			cachePath:   "/",
 			data:        "root",
 			numChildren: 2,
 		},
 		{
-			path:        "/test-tree-cache/child1",
+			realPath:    "/test-tree-cache/child1",
 			cachePath:   "/child1",
 			data:        "child1",
 			numChildren: 1,
 		},
 		{
-			path:        "/test-tree-cache/child1/child1_1",
+			realPath:    "/test-tree-cache/child1/child1_1",
 			cachePath:   "/child1/child1_1",
 			data:        "child1_1",
 			numChildren: 0,
 		},
 		{
-			path:        "/test-tree-cache/child2",
+			realPath:    "/test-tree-cache/child2",
 			cachePath:   "/child2",
 			data:        "child2",
 			numChildren: 1,
 		},
 		{
-			path:        "/test-tree-cache/child2/child2_1",
+			realPath:    "/test-tree-cache/child2/child2_1",
 			cachePath:   "/child2/child2_1",
 			data:        "child2_1",
 			numChildren: 0,
@@ -48,13 +49,15 @@ func TestTreeCache_ConsistentAfterInitialSync(t *testing.T) {
 	WithTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "}, func(t *testing.T, tc *TestCluster) {
 		WithConnectAll(t, tc, func(t *testing.T, c *Conn, _ <-chan Event) {
 			for _, n := range initialNodes {
-				_, err := c.Create(n.path, []byte(n.data), 0, WorldACL(PermAll))
+				_, err := c.Create(n.realPath, []byte(n.data), 0, WorldACL(PermAll))
 				if err != nil {
-					t.Fatalf("failed to create node %s: %v", n.path, err)
+					t.Fatalf("failed to create node %s: %v", n.realPath, err)
 				}
 			}
 
-			cache := NewTreeCache(c, "/test-tree-cache", true)
+			// By default, paths a relative to root.
+			cache := NewTreeCache(c, "/test-tree-cache",
+				TreeCacheIncludeData(true))
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 			defer cancel()
 
@@ -94,6 +97,277 @@ func TestTreeCache_ConsistentAfterInitialSync(t *testing.T) {
 	})
 }
 
+func TestTreeCache_OpsWithRelativePaths(t *testing.T) {
+	initialNodes := []struct {
+		realPath string
+		data     string
+	}{
+		{
+			realPath: "/test-tree-cache",
+			data:     "root",
+		},
+		{
+			realPath: "/test-tree-cache/child1",
+			data:     "child1",
+		},
+		{
+			realPath: "/test-tree-cache/child1/child1_1",
+			data:     "child1_1",
+		},
+		{
+			realPath: "/test-tree-cache/child2",
+			data:     "child2",
+		},
+		{
+			realPath: "/test-tree-cache/child2/child2_1",
+			data:     "child2_1",
+		},
+	}
+
+	WithTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "}, func(t *testing.T, tc *TestCluster) {
+		WithConnectAll(t, tc, func(t *testing.T, c *Conn, _ <-chan Event) {
+			for _, n := range initialNodes {
+				_, err := c.Create(n.realPath, []byte(n.data), 0, WorldACL(PermAll))
+				if err != nil {
+					t.Fatalf("failed to create node %s: %v", n.realPath, err)
+				}
+			}
+
+			cache := NewTreeCache(c, "/test-tree-cache",
+				TreeCacheIncludeData(true))
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			defer cancel()
+
+			syncErrCh := make(chan error, 1)
+
+			// Start syncing cache in the background.
+			go func() {
+				defer close(syncErrCh)
+				syncErrCh <- cache.Sync(ctx)
+			}()
+
+			// Wait for the first full sync to complete.
+			err := cache.WaitForInitialSync(ctx)
+			if err != nil {
+				t.Fatalf("initial cache sync failed: %v", err)
+			}
+
+			// Get the root node.
+			data, stat, err := cache.Get("/")
+			if err != nil {
+				t.Fatalf("failed to get cache node /: %v", err)
+			}
+			if string(data) != "root" {
+				t.Fatalf("cahce node / data mismatch: expected %s, got %s", "root", string(data))
+			}
+			if stat.NumChildren != 2 {
+				t.Fatalf("cache node / numChildren mismatch: expected %d, got %d", 2, stat.NumChildren)
+			}
+
+			// Get a leaf node.
+			data, stat, err = cache.Get("/child1/child1_1")
+			if err != nil {
+				t.Fatalf("failed to get cache node /child1/child1_1: %v", err)
+			}
+			if string(data) != "child1_1" {
+				t.Fatalf("cahce node /child1/child1_1 data mismatch: expected %s, got %s", "child1_1", string(data))
+			}
+			if stat.NumChildren != 0 {
+				t.Fatalf("cache node /child1/child1_1 numChildren mismatch: expected %d, got %d", 0, stat.NumChildren)
+			}
+
+			// Get node that does no
+
+			cancel()
+			if err := <-syncErrCh; err != context.Canceled {
+				t.Fatalf("expected context.Canceled, got %v", err)
+			}
+
+			// Existence.
+			var found bool
+			found, _, err = cache.Exists("/child1/child1_1")
+			if err != nil {
+				t.Fatalf("failed to exists cache node /child1/child1_1: %v", err)
+			}
+			if !found {
+				t.Fatalf("cache node /child1/child1_1 not found")
+			}
+			found, _, err = cache.Exists("/foo")
+			if found {
+				t.Fatalf("cache node /foo found")
+			}
+
+			// Root children.
+			var children []string
+			children, _, err = cache.Children("/")
+			if err != nil {
+				t.Fatalf("failed to get children for cache node /child1/child1_1: %v", err)
+			}
+			if len(children) != 2 {
+				t.Fatalf("cache node / children mismatch: expected %d, got %d", 2, len(children))
+			}
+			sort.Strings(children) // For consistency.
+			if children[0] != "child1" || children[1] != "child2" {
+				t.Fatalf("cache node / children mismatch: expected %v, got %v", []string{"child1", "child2"}, children)
+			}
+
+			// Walking from root.
+			var visited []string
+			walker := cache.Walker("/")
+			walker.IncludeRoot(true).
+				DepthFirst().
+				Walk(func(path string, stat *Stat) error {
+					visited = append(visited, path)
+					return nil
+				})
+			sort.Strings(visited) // For consistency.
+			if len(visited) != 5 {
+				t.Fatalf("cache walker visited mismatch: expected %d, got %d", 5, len(visited))
+			}
+			if visited[0] != "/" ||
+				visited[1] != "/child1" ||
+				visited[2] != "/child1/child1_1" ||
+				visited[3] != "/child2" ||
+				visited[4] != "/child2/child2_1" {
+				t.Fatalf("cache walker visited mismatch: expected %v, got %v", []string{"/", "/child1", "/child1/child1_1", "/child2", "/child2/child2_1"}, visited)
+			}
+		})
+	})
+}
+
+func TestTreeCache_OpsWithAbsolutePaths(t *testing.T) {
+	initialNodes := []struct {
+		realPath string
+		data     string
+	}{
+		{
+			realPath: "/test-tree-cache",
+			data:     "root",
+		},
+		{
+			realPath: "/test-tree-cache/child1",
+			data:     "child1",
+		},
+		{
+			realPath: "/test-tree-cache/child1/child1_1",
+			data:     "child1_1",
+		},
+		{
+			realPath: "/test-tree-cache/child2",
+			data:     "child2",
+		},
+		{
+			realPath: "/test-tree-cache/child2/child2_1",
+			data:     "child2_1",
+		},
+	}
+
+	WithTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "}, func(t *testing.T, tc *TestCluster) {
+		WithConnectAll(t, tc, func(t *testing.T, c *Conn, _ <-chan Event) {
+			for _, n := range initialNodes {
+				_, err := c.Create(n.realPath, []byte(n.data), 0, WorldACL(PermAll))
+				if err != nil {
+					t.Fatalf("failed to create node %s: %v", n.realPath, err)
+				}
+			}
+
+			cache := NewTreeCache(c, "/test-tree-cache",
+				TreeCacheIncludeData(true),
+				TreeCacheAbsolutePaths(true))
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			defer cancel()
+
+			syncErrCh := make(chan error, 1)
+
+			// Start syncing cache in the background.
+			go func() {
+				defer close(syncErrCh)
+				syncErrCh <- cache.Sync(ctx)
+			}()
+
+			// Wait for the first full sync to complete.
+			err := cache.WaitForInitialSync(ctx)
+			if err != nil {
+				t.Fatalf("initial cache sync failed: %v", err)
+			}
+
+			// Get the root node.
+			data, stat, err := cache.Get("/test-tree-cache")
+			if err != nil {
+				t.Fatalf("failed to get cache node /test-tree-cache: %v", err)
+			}
+			if string(data) != "root" {
+				t.Fatalf("cahce node /test-tree-cache data mismatch: expected %s, got %s", "root", string(data))
+			}
+			if stat.NumChildren != 2 {
+				t.Fatalf("cache node /test-tree-cache numChildren mismatch: expected %d, got %d", 2, stat.NumChildren)
+			}
+
+			// Get a leaf node.
+			data, stat, err = cache.Get("/test-tree-cache/child1/child1_1")
+			if err != nil {
+				t.Fatalf("failed to get cache node /test-tree-cache/child1/child1_1: %v", err)
+			}
+			if string(data) != "child1_1" {
+				t.Fatalf("cahce node /test-tree-cache/child1/child1_1 data mismatch: expected %s, got %s", "child1_1", string(data))
+			}
+			if stat.NumChildren != 0 {
+				t.Fatalf("cache node /test-tree-cache/child1/child1_1 numChildren mismatch: expected %d, got %d", 0, stat.NumChildren)
+			}
+
+			cancel()
+			if err := <-syncErrCh; err != context.Canceled {
+				t.Fatalf("expected context.Canceled, got %v", err)
+			}
+
+			// Existence.
+			var found bool
+			found, _, err = cache.Exists("/test-tree-cache/child1/child1_1")
+			if err != nil {
+				t.Fatalf("failed to exists cache node /test-tree-cache/child1/child1_1: %v", err)
+			}
+			if !found {
+				t.Fatalf("cache node /test-tree-cache/child1/child1_1 not found")
+			}
+
+			// Root children.
+			var children []string
+			children, _, err = cache.Children("/test-tree-cache")
+			if err != nil {
+				t.Fatalf("failed to fetch children for cache node /test-tree-cache/child1/child1_1: %v", err)
+			}
+			if len(children) != 2 {
+				t.Fatalf("cache node /test-tree-cache children mismatch: expected %d, got %d", 2, len(children))
+			}
+			sort.Strings(children) // For consistency.
+			if children[0] != "child1" || children[1] != "child2" {
+				t.Fatalf("cache node /test-tree-cache/children mismatch: expected %v, got %v", []string{"child1", "child2"}, children)
+			}
+
+			// Walking from root.
+			var visited []string
+			walker := cache.Walker("/test-tree-cache")
+			walker.IncludeRoot(true).
+				DepthFirst().
+				Walk(func(path string, stat *Stat) error {
+					visited = append(visited, path)
+					return nil
+				})
+			sort.Strings(visited) // For consistency.
+			if len(visited) != 5 {
+				t.Fatalf("cache walker visited mismatch: expected %d, got %d", 5, len(visited))
+			}
+			if visited[0] != "/test-tree-cache" ||
+				visited[1] != "/test-tree-cache/child1" ||
+				visited[2] != "/test-tree-cache/child1/child1_1" ||
+				visited[3] != "/test-tree-cache/child2" ||
+				visited[4] != "/test-tree-cache/child2/child2_1" {
+				t.Fatalf("cache walker visited mismatch: expected %v, got %v", []string{"/", "/child1", "/child1/child1_1", "/child2", "/child2/child2_1"}, visited)
+			}
+		})
+	})
+}
+
 func TestTreeCache_WatchesNodeCreate(t *testing.T) {
 	WithTestCluster(t, 1, nil, logWriter{t: t, p: "[ZKERR] "}, func(t *testing.T, tc *TestCluster) {
 		WithConnectAll(t, tc, func(t *testing.T, c *Conn, _ <-chan Event) {
@@ -102,7 +376,8 @@ func TestTreeCache_WatchesNodeCreate(t *testing.T) {
 				t.Fatalf("failed to create node %s: %v", "/test-tree-cache", err)
 			}
 
-			cache := NewTreeCache(c, "/test-tree-cache", true)
+			cache := NewTreeCache(c, "/test-tree-cache",
+				TreeCacheIncludeData(true))
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 			defer cancel()
 
@@ -163,7 +438,8 @@ func TestTreeCache_WatchesNodeUpdate(t *testing.T) {
 				t.Fatalf("failed to create node %s: %v", "/test-tree-cache/child1", err)
 			}
 
-			cache := NewTreeCache(c, "/test-tree-cache", true)
+			cache := NewTreeCache(c, "/test-tree-cache",
+				TreeCacheIncludeData(true))
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 			defer cancel()
 
@@ -215,7 +491,8 @@ func TestTreeCache_WatchesNodeDelete(t *testing.T) {
 				t.Fatalf("failed to create node %s: %v", "/test-tree-cache/child1", err)
 			}
 
-			cache := NewTreeCache(c, "/test-tree-cache", true)
+			cache := NewTreeCache(c, "/test-tree-cache",
+				TreeCacheIncludeData(true))
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 			defer cancel()
 


### PR DESCRIPTION
Changed `TreeCache` constructor to accept var-args slice of options.

```go
func NewTreeCache(conn *Conn, path string, options ...TreeCacheOption) *TreeCache
```

New options:

```go
// TreeCacheIncludeData returns an option to include data in the tree cache.
func TreeCacheIncludeData(includeData bool) TreeCacheOption 
```

```go
// TreeCacheAbsolutePaths returns an option to use full/absolute paths in the tree cache.
// Normally, the cache reports paths relative to the node it is rooted at.
// For example, if the cache is rooted at "/foo" and "/foo/bar" is created, the cache reports the node as "/bar".
// With absolute paths enabled, the cache reports the node as "/foo/bar".
func TreeCacheAbsolutePaths(absolutePaths bool) TreeCacheOption
```

```go 
// TreeCacheLogger returns an option that sets the logger to use for the tree cache.
func TreeCacheLogger(logger Logger) TreeCacheOption
```