### PR TITLE
Reworked `TreeWalker` for bounded concurrency

### DIFF
--- a/_examples/tree_walker.go
+++ b/_examples/tree_walker.go
@@ -44,7 +44,8 @@ func main() {
 
 	// Walk breath-first with parallel traversal and receive events by channel.
 	ch := c.TreeWalker("/foo").
-		BreadthFirstParallel().
+		BreadthFirst().
+		Concurrency(4).
 		WalkChan(8) // You can tune the buffer size.
 	for e := range ch {
 		if e.Err != nil {

--- a/cached_leaves_walker.go
+++ b/cached_leaves_walker.go
@@ -38,7 +38,8 @@ func NewCachedLeavesWalker(conn *Conn, path string) (*CachedLeavesWalker, error)
 
 	go w.eventLoop()
 	if err = conn.TreeWalker(path).
-		BreadthFirstParallel().
+		BreadthFirst().
+		Concurrency(8). // This is just randomly chosen.
 		LeavesOnly().
 		Walk(func(p string, _ *Stat) error {
 			w.lock.Lock()

--- a/tree_walker.go
+++ b/tree_walker.go
@@ -3,6 +3,7 @@ package zk
 import (
 	"context"
 	gopath "path"
+	"sync"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -31,20 +32,25 @@ func InitTreeWalker(fetcher ChildrenFunc, path string) TreeWalker {
 		path:        path,
 		includeRoot: true,
 		walker:      walkBreadthFirst,
+		lifo:        false,
 		decorator:   func(v VisitorCtxFunc) VisitorCtxFunc { return v }, // Identity.
+		concurrency: 1,
 	}
 }
 
 // TreeWalker provides flexible traversal of a tree of nodes rooted at a specific path.
-// The traversal can be configured by calling one of DepthFirst, DepthFirstParallel, BreadthFirst, or BreadthFirstParallel.
+// The traversal can be configured by calling one of DepthFirst, BreadthFirst.
 // By default, the walker will visit the root node, but this can be changed by calling IncludeRoot.
-// The walker can also be configured to only visit leaf nodes by calling LeavesOnly.
+// The walker can be configured to only visit leaf nodes by calling LeavesOnly.
+// The concurrency level can be configured by calling Concurrency; the default is 1.
 type TreeWalker struct {
-	fetcher     ChildrenFunc
-	path        string
-	includeRoot bool
-	walker      walkFunc
-	decorator   visitorDecoratorFunc
+	fetcher     ChildrenFunc         // Function that returns the children of a node.
+	path        string               // The path to root node.
+	includeRoot bool                 // Whether to include the root node in the traversal.
+	walker      walkFunc             // The function that performs the walk steps of traversal.
+	lifo        bool                 // Whether process traversal steps in LIFO order; only used by depth-first traversal.
+	decorator   visitorDecoratorFunc // Decorates the visitor function.
+	concurrency int                  // The number of workers to use for traversal; default is 1.
 }
 
 // DepthFirst configures the walker for a sequential traversal in depth-first order.
@@ -54,19 +60,9 @@ func (w TreeWalker) DepthFirst() TreeWalker {
 		path:        w.path,
 		includeRoot: w.includeRoot,
 		walker:      walkDepthFirst,
+		lifo:        true,
 		decorator:   w.decorator,
-	}
-}
-
-// DepthFirstParallel configures the walker a parallel traversal in depth-first order.
-// Note: Parallel traversal will break strict depth-first ordering, since children are visited in parallel.
-func (w TreeWalker) DepthFirstParallel() TreeWalker {
-	return TreeWalker{
-		fetcher:     w.fetcher,
-		path:        w.path,
-		includeRoot: w.includeRoot,
-		walker:      walkDepthFirstParallel,
-		decorator:   w.decorator,
+		concurrency: w.concurrency,
 	}
 }
 
@@ -77,19 +73,9 @@ func (w TreeWalker) BreadthFirst() TreeWalker {
 		path:        w.path,
 		includeRoot: w.includeRoot,
 		walker:      walkBreadthFirst,
+		lifo:        false,
 		decorator:   w.decorator,
-	}
-}
-
-// BreadthFirstParallel configures the walker for a parallel traversal in breadth-first order.
-// Note: Parallel traversal will break strict breadth-first ordering, since children are visited in parallel.
-func (w TreeWalker) BreadthFirstParallel() TreeWalker {
-	return TreeWalker{
-		fetcher:     w.fetcher,
-		path:        w.path,
-		includeRoot: w.includeRoot,
-		walker:      walkBreadthFirstParallel,
-		decorator:   w.decorator,
+		concurrency: w.concurrency,
 	}
 }
 
@@ -100,7 +86,9 @@ func (w TreeWalker) IncludeRoot(included bool) TreeWalker {
 		path:        w.path,
 		includeRoot: included,
 		walker:      w.walker,
+		lifo:        w.lifo,
 		decorator:   w.decorator,
+		concurrency: w.concurrency,
 	}
 }
 
@@ -111,6 +99,7 @@ func (w TreeWalker) LeavesOnly() TreeWalker {
 		path:        w.path,
 		includeRoot: w.includeRoot,
 		walker:      w.walker,
+		lifo:        w.lifo,
 		decorator: func(v VisitorCtxFunc) VisitorCtxFunc {
 			// Only call the original visitor if the node has no children.
 			return func(ctx context.Context, path string, stat *Stat) error {
@@ -120,6 +109,20 @@ func (w TreeWalker) LeavesOnly() TreeWalker {
 				return nil
 			}
 		},
+		concurrency: w.concurrency,
+	}
+}
+
+// Concurrency configures the walker with the specified concurrency level.
+func (w TreeWalker) Concurrency(concurrency int) TreeWalker {
+	return TreeWalker{
+		fetcher:     w.fetcher,
+		path:        w.path,
+		includeRoot: w.includeRoot,
+		walker:      w.walker,
+		lifo:        w.lifo,
+		decorator:   w.decorator,
+		concurrency: concurrency,
 	}
 }
 
@@ -135,8 +138,51 @@ func (w TreeWalker) Walk(visitor VisitorFunc) error {
 
 // WalkCtx is like Walk, but takes a context that can be used to cancel the walk.
 func (w TreeWalker) WalkCtx(ctx context.Context, visitor VisitorCtxFunc) error {
-	visitor = w.decorator(visitor) // Apply decorator.
-	return w.walker(ctx, w.fetcher, w.path, w.includeRoot, visitor)
+	visitor = w.decorator(visitor)                  // Apply decorator.
+	steps := newTraversalBuffer(w.lifo)             // Buffer for traversal steps.
+	workers, workerCtx := errgroup.WithContext(ctx) // Tracks the workers and the context for the entire walk.
+
+	go func() {
+		// As soon as the worker context is cancelled, abort the buffer to unblock callers of consumeNext.
+		<-workerCtx.Done()
+		steps.abort() // No-op if already complete.
+	}()
+
+	// Start the workers, each of which will consume steps from buffer and execute them.
+	for i := 0; i < w.concurrency; i++ {
+		workers.Go(func() error {
+			for {
+				select {
+				case <-workerCtx.Done():
+					return workerCtx.Err() // Context was cancelled.
+				default:
+				}
+
+				ok, err := steps.consumeNext(func(step traversalStep) error {
+					if step.op == treeOpVisit {
+						return visitor(workerCtx, step.path, step.stat)
+					}
+					return w.walker(workerCtx, w.fetcher, step, steps)
+				})
+				if err != nil {
+					return err // Error occurred.
+				}
+				if !ok {
+					return nil // Done.
+				}
+			}
+		})
+	}
+
+	// Start the traversal: add the root path to step buffer.
+	if w.includeRoot {
+		steps.add(traversalStep{op: treeOpWalkIncludeSelf, path: w.path})
+	} else {
+		steps.add(traversalStep{op: treeOpWalkExcludeSelf, path: w.path})
+	}
+
+	// Wait for all workers to exit, or for an error to occur.
+	return workers.Wait()
 }
 
 // WalkChan begins traversing the tree and sends the results to the returned channel.
@@ -163,19 +209,151 @@ func (w TreeWalker) WalkChanCtx(ctx context.Context, bufferSize int) <-chan Visi
 	return ch
 }
 
-// walkFunc is a function that implements a recursive tree traversal.
-type walkFunc func(ctx context.Context, fetcher ChildrenFunc, path string, includeSelf bool, visitor VisitorCtxFunc) error
+// treeOp represent a type of operation to perform on a node during a tree traversal.
+type treeOp int
+
+const (
+	// treeOpWalkIncludeSelf indicates that the node should be visited and its children should be traversed.
+	treeOpWalkIncludeSelf treeOp = iota
+
+	// treeOpWalkExcludeSelf indicates that the node should not be visited, but its children should be traversed.
+	treeOpWalkExcludeSelf
+
+	// treeOpVisit indicates that the node should be visited.
+	treeOpVisit
+)
+
+// traverseStep describes a step in a tree traversal, including the path and the operation to perform.
+type traversalStep struct {
+	op   treeOp // The operation to perform.
+	path string // The path to traverse.
+	stat *Stat  // Only used for treeOpVisit.
+}
+
+type traversalStepAdder interface {
+	add(step traversalStep)
+}
+
+func newTraversalBuffer(lifo bool) *traversalBuffer {
+	q := &traversalBuffer{
+		buf:     make([]traversalStep, 0),
+		lifo:    lifo,
+		pending: 0,
+	}
+	q.nonEmptyCond = sync.NewCond(&q.mu) // Signals when the buffer is non-empty.
+	return q
+}
+
+type traversalBuffer struct {
+	buf          []traversalStep // The buffer of steps to be consumed.
+	lifo         bool            // True if the buffer should be treated as a LIFO; otherwise FIFO.
+	pending      int32           // Number of pending steps. Set to -1 when traversal is complete.
+	mu           sync.Mutex      // Protects all fields.
+	nonEmptyCond *sync.Cond      // Signals when the buffer is non-empty.
+}
+
+func (tb *traversalBuffer) add(step traversalStep) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	if tb.pending < 0 { // Anything < 0 means traversal is complete.
+		panic("traversalBuffer: add called after traversal was complete")
+	}
+
+	tb.pending++
+	tb.buf = append(tb.buf, step)
+	tb.nonEmptyCond.Signal()
+}
+
+func (tb *traversalBuffer) consumeNext(consumer func(step traversalStep) error) (bool, error) {
+	tb.mu.Lock()
+
+	// Wait until the buffer is non-empty, the context is canceled or traversal is complete.
+	for {
+		if tb.pending < 0 { // Anything < 0 means traversal is complete.
+			tb.mu.Unlock()
+			return false, nil // Nothing left to do.
+		}
+		if len(tb.buf) == 0 {
+			// Wait for more steps to be added.
+			// This must also be signalled if traversal is aborted or completed while waiting.
+			tb.nonEmptyCond.Wait()
+		} else {
+			break
+		}
+	}
+
+	var step traversalStep
+
+	if tb.lifo {
+		// Pop the last element.
+		step = tb.buf[len(tb.buf)-1]
+		tb.buf = tb.buf[:len(tb.buf)-1]
+	} else {
+		// Pop the first element.
+		step = tb.buf[0]
+		tb.buf = tb.buf[1:]
+	}
+	tb.mu.Unlock()
+
+	// Call the consumer outside the lock.
+	// This allows the consumer to add more steps to the buffer.
+	err := consumer(step)
+
+	tb.mu.Lock()
+	tb.pending--         // Note: This can go < 0 if traversal was aborted during consume, and that is perfectly fine.
+	if tb.pending == 0 { // We just completed the last step!
+		tb.pending = -1             // Set to -1 to indicate that traversal is complete.
+		tb.nonEmptyCond.Broadcast() // Wake up all waiters.
+	}
+	tb.mu.Unlock()
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (tb *traversalBuffer) abort() {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	if tb.pending < 0 {
+		return // Already complete.
+	}
+
+	tb.pending = -1 // Anything < 0 means traversal is complete.
+	tb.buf = nil
+	tb.nonEmptyCond.Broadcast()
+}
+
+// walkFunc is a function that implements a single walk step of tree traversal.
+// The fetcher function is used to fetch the children of a node.
+// The current step describes the current node and the operation to perform.
+// The adder function is used to add new traversal steps (ex: for children of the current node).
+type walkFunc func(
+	ctx context.Context,
+	fetcher ChildrenFunc,
+	current traversalStep,
+	adder traversalStepAdder,
+) error
 
 // visitorDecoratorFunc is a function that decorates a visitor function.
 type visitorDecoratorFunc func(v VisitorCtxFunc) VisitorCtxFunc
 
-// walkDepthFirst walks the tree rooted at path in depth-first order.
-func walkDepthFirst(ctx context.Context, fetcher ChildrenFunc, path string, includeSelf bool, visitor VisitorCtxFunc) error {
+// walkDepthFirst implements the walk step of depth-first tree traversal.
+func walkDepthFirst(
+	ctx context.Context,
+	fetcher ChildrenFunc,
+	current traversalStep,
+	stack traversalStepAdder,
+) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
 
-	children, stat, err := fetcher(ctx, path)
+	children, stat, err := fetcher(ctx, current.path)
 	if err != nil {
 		if err == ErrNoNode {
 			return nil // Ignore ErrNoNode.
@@ -183,29 +361,32 @@ func walkDepthFirst(ctx context.Context, fetcher ChildrenFunc, path string, incl
 		return err
 	}
 
-	for _, child := range children {
-		childPath := gopath.Join(path, child)
-		if err = walkDepthFirst(ctx, fetcher, childPath, true, visitor); err != nil {
-			return err
-		}
+	// Push visit step first so it will be processed after children (LIFO).
+	if current.op == treeOpWalkIncludeSelf {
+		stack.add(traversalStep{op: treeOpVisit, path: current.path, stat: stat})
 	}
 
-	if includeSelf {
-		if err = visitor(ctx, path, stat); err != nil {
-			return err
-		}
+	// Add children in reverse order to account for LIFO processing order.
+	// We desire children to be processed in left-to-right order (as returned by fetcher).
+	for i := len(children) - 1; i >= 0; i-- {
+		stack.add(traversalStep{op: treeOpWalkIncludeSelf, path: gopath.Join(current.path, children[i])})
 	}
 
 	return nil
 }
 
-// walkDepthFirstParallel walks the tree rooted at path in depth-first order, but in parallel.
-func walkDepthFirstParallel(ctx context.Context, fetcher ChildrenFunc, path string, includeSelf bool, visitor VisitorCtxFunc) error {
+// walkBreadthFirst implements the walk step of breadth-first tree traversal.
+func walkBreadthFirst(
+	ctx context.Context,
+	fetcher ChildrenFunc,
+	current traversalStep,
+	queue traversalStepAdder,
+) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
 
-	children, stat, err := fetcher(ctx, path)
+	children, stat, err := fetcher(ctx, current.path)
 	if err != nil {
 		if err == ErrNoNode {
 			return nil // Ignore ErrNoNode.
@@ -213,81 +394,15 @@ func walkDepthFirstParallel(ctx context.Context, fetcher ChildrenFunc, path stri
 		return err
 	}
 
-	eg, egctx := errgroup.WithContext(ctx)
+	if current.op == treeOpWalkIncludeSelf {
+		queue.add(traversalStep{op: treeOpVisit, path: current.path, stat: stat})
+	}
+
+	// Add children in order to account for FIFO processing order.
+	// We desire children to be visited left-to-right order (as returned by fetcher).
 	for _, child := range children {
-		childPath := gopath.Join(path, child)
-		eg.Go(func() error {
-			return walkDepthFirstParallel(egctx, fetcher, childPath, true, visitor)
-		})
-	}
-
-	if includeSelf {
-		eg.Go(func() error {
-			return visitor(egctx, path, stat)
-		})
-	}
-
-	return eg.Wait()
-}
-
-// walkBreadthFirst walks the tree rooted at path in breadth-first order.
-func walkBreadthFirst(ctx context.Context, fetcher ChildrenFunc, path string, includeSelf bool, visitor VisitorCtxFunc) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-
-	children, stat, err := fetcher(ctx, path)
-	if err != nil {
-		if err == ErrNoNode {
-			return nil // Ignore ErrNoNode.
-		}
-		return err
-	}
-
-	if includeSelf {
-		if err = visitor(ctx, path, stat); err != nil {
-			return err
-		}
-	}
-
-	for _, child := range children {
-		childPath := gopath.Join(path, child)
-		if err = walkBreadthFirst(ctx, fetcher, childPath, true, visitor); err != nil {
-			return err
-		}
+		queue.add(traversalStep{op: treeOpWalkIncludeSelf, path: gopath.Join(current.path, child)})
 	}
 
 	return nil
-}
-
-// walkBreadthFirstParallel walks the tree rooted at path in breadth-first order, but in parallel.
-func walkBreadthFirstParallel(ctx context.Context, fetcher ChildrenFunc, path string, includeSelf bool, visitor VisitorCtxFunc) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-
-	children, stat, err := fetcher(ctx, path)
-	if err != nil {
-		if err == ErrNoNode {
-			return nil // Ignore ErrNoNode.
-		}
-		return err
-	}
-
-	eg, egctx := errgroup.WithContext(ctx)
-
-	if includeSelf {
-		eg.Go(func() error {
-			return visitor(egctx, path, stat)
-		})
-	}
-
-	for _, child := range children {
-		childPath := gopath.Join(path, child)
-		eg.Go(func() error {
-			return walkBreadthFirstParallel(egctx, fetcher, childPath, true, visitor)
-		})
-	}
-
-	return eg.Wait()
 }


### PR DESCRIPTION
## What?
Reworked `TreeWalker` for bounded concurrency; refactored `TreeCache` as well.

The `TreeWalker` has been completely overhauled. Previously, we used call recursion and parallelized the branches of traversal, but this proved difficult to control the level of concurrency. With this PR, a new algorithm splits node traversal into a sequence of steps that are submitted to a pool of workers with 1 or more goroutines (fixed number of your choosing). The coordination of steps is performed by `traversalBuffer`, which acts as a thread-safe queue (FIFO) for breadth-first traversal, or as a thread-safe stack (LIFO) for depth-first traversal. 

## Why?
Unbounded concurrency proved to be naive and prone to overload the TCP socket, resulting in hanging of all requests on the ZK client. 
