### PR TITLE
Log which erroneous path is returning an error

### DIFF
--- a/tree_cache.go
+++ b/tree_cache.go
@@ -620,7 +620,7 @@ func (tc *TreeCache) toInternalPath(externalPath string) (string, error) {
 	if tc.absolutePaths {
 		// We expect externalPath to be prefixed by rootPath.
 		if !strings.HasPrefix(externalPath, tc.rootPath) {
-			return "", fmt.Errorf("path was outside of cache scope: %s", tc.rootPath)
+			return "", fmt.Errorf("path %q was outside of cache scope: %q", externalPath, tc.rootPath)
 		}
 		// Ex: rootPath="/foo", externalPath="/foo/bar" => internalPath="/bar"
 		return externalPath[len(tc.rootPath):], nil


### PR DESCRIPTION
We have thousands of 
```
[ERROR] plugin/mcs: OnSyncError: err=path was outside of cache scope: /mcs.v1
```
[In the coredns logs](https://logs.shopify.io/en-US/app/search/search?sid=1694206314.73541_AA2ADAB8-6470-4BC2-8017-261700985E83).
This increments the metric for error and [sometimes pages us](https://observe.shopify.io/a/shopify-observe/monitoring/alertRules/369bdeb0-de5c-4098-8d86-e903ef9778b2?from=1694203757664&to=1694204906797&updateTimeRange=7).

Let's log which path the error is returned for so we can at least investigate that.