### PR TITLE
fix(treecache): use correct path to call Get()

### DIFF
--- a/tree_cache.go
+++ b/tree_cache.go
@@ -442,7 +442,7 @@ func (tc *TreeCache) doSync(ctx context.Context) error {
 					} // else, we'll get an EventNodeDeleted later.
 				}
 				if tc.includeData && tc.listener != nil {
-					data, stat, err := tc.Get(relPath)
+					data, stat, err := tc.Get(e.Path)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
Get expects the full path as parameter but relPath is trimmed from the root prefix.

This fixes alerts like
```
[ERROR] plugin/mcs: OnSyncError: err=path was outside of cache scope: /mcs.v1
```