### PR TITLE
Fix ErrNoNode in OnNodeDeleting

### DIFF
--- a/tree_cache_listener_mock.go
+++ b/tree_cache_listener_mock.go
@@ -1,0 +1,162 @@
+package zk
+
+import (
+	"sync"
+	"time"
+)
+
+// TreeCacheListenerMock is a mock implementation of TreeCacheListener.
+type TreeCacheListenerMock struct {
+	mu sync.Mutex
+
+	onSyncStartedCalled int
+	onSyncStoppedCalled int
+	onSyncErrorCalled   int
+	onTreeSyncedCalled  int
+
+	onNodeCreatedCalled int
+	nodesCreated        map[string][]byte
+
+	onNodeDataChangedCalled int
+	nodesDataChanged        map[string][]byte
+
+	onNodeDeletingCalled int
+	nodesDeleting        map[string][]byte
+
+	onNodeDeletedCalled int
+	nodesDeleted        map[string]string
+}
+
+func NewTreeCacheListenerMock() *TreeCacheListenerMock {
+	return &TreeCacheListenerMock{
+		mu:               sync.Mutex{},
+		nodesCreated:     make(map[string][]byte),
+		nodesDeleting:    make(map[string][]byte),
+		nodesDeleted:     make(map[string]string),
+		nodesDataChanged: make(map[string][]byte),
+	}
+}
+
+func (m *TreeCacheListenerMock) OnSyncStarted() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onSyncStartedCalled++
+}
+
+func (m *TreeCacheListenerMock) OnSyncStopped(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onSyncStoppedCalled++
+}
+
+func (m *TreeCacheListenerMock) OnSyncError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onSyncErrorCalled++
+}
+
+func (m *TreeCacheListenerMock) OnTreeSynced(elapsed time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onTreeSyncedCalled++
+}
+
+func (m *TreeCacheListenerMock) OnNodeCreated(path string, data []byte, stat *Stat) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onNodeCreatedCalled++
+	m.nodesCreated[path] = data
+}
+
+func (m *TreeCacheListenerMock) OnNodeDeleting(path string, data []byte, stat *Stat) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onNodeDeletingCalled++
+	m.nodesDeleting[path] = data
+}
+
+func (m *TreeCacheListenerMock) OnNodeDeleted(path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onNodeDeletedCalled++
+	m.nodesDeleted[path] = path
+}
+
+func (m *TreeCacheListenerMock) OnNodeDataChanged(path string, data []byte, stat *Stat) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onNodeDataChangedCalled++
+	m.nodesDataChanged[path] = data
+}
+
+func (m *TreeCacheListenerMock) OnSyncStartedCalled() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.onSyncStartedCalled
+}
+
+func (m *TreeCacheListenerMock) OnSyncStoppedCalled() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.onSyncStoppedCalled
+}
+
+func (m *TreeCacheListenerMock) OnSyncErrorCalled() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.onSyncErrorCalled
+}
+
+func (m *TreeCacheListenerMock) OnTreeSyncedCalled() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.onTreeSyncedCalled
+}
+
+func (m *TreeCacheListenerMock) OnNodeCreatedCalled() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.onNodeCreatedCalled
+}
+
+func (m *TreeCacheListenerMock) NodesCreated() map[string][]byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.nodesCreated
+}
+
+func (m *TreeCacheListenerMock) OnNodeDataChangedCalled() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.onNodeDataChangedCalled
+}
+
+func (m *TreeCacheListenerMock) NodesDataChanged() map[string][]byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.nodesDataChanged
+}
+
+func (m *TreeCacheListenerMock) OnNodeDeletingCalled() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.onNodeDeletingCalled
+}
+
+func (m *TreeCacheListenerMock) NodesDeleting() map[string][]byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.nodesDeleting
+}
+
+func (m *TreeCacheListenerMock) OnNodeDeletedCalled() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.onNodeDeletedCalled
+}
+
+func (m *TreeCacheListenerMock) NodesDeleted() map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.nodesDeleted
+}


### PR DESCRIPTION
Ref: #39, #40, #41

## Fix ErrNoNode when the node doesn't exists in TreeCache

In dynamic environments when there are so many event happening, TreeCache may have some data when it receives a Delete event, so it fails on reading data from cache. In this case we still want to call the listener because we received the event but we don't have any data to pass on. 

Here is an example of this behaviour that we saw in KateSQL:
```json
2023/10/06 16:59:34 synced tree cache in 3.548771636s
{"level":"info","elapsed":3548.771636,"time":"2023-10-06T16:59:34Z","message":"zk tree cache synced"}
{"level":"error","error":"zk: node does not exist","time":"2023-10-06T16:59:34Z","message":"zk tree cache sync error"}
2023/10/06 16:59:34 failed to sync tree cache: zk: node does not exist
2023/10/06 16:59:37 synced tree cache in 3.278106813s
{"level":"info","elapsed":3278.106813,"time":"2023-10-06T16:59:37Z","message":"zk tree cache synced"}
{"level":"error","error":"zk: node does not exist","time":"2023-10-06T16:59:38Z","message":"zk tree cache sync error"}
2023/10/06 16:59:38 failed to sync tree cache: zk: node does not exist
2023/10/06 16:59:41 synced tree cache in 3.243859049s
{"level":"info","elapsed":3243.859049,"time":"2023-10-06T16:59:41Z","message":"zk tree cache synced"}
```

## Fix `EventNodeDeleted` with `absolutePaths == false`
This PR also fixes a bug when it always throws error on `EventNodeDeleted` when `absolutePaths == false`, because `tc.Get` expects to get the correct path from the user based on the `absolutePaths` setting.


## 🎩 On WatchKeeper Production with this fix, there is no `failed to sync error` in 20 minutes 
```json
{"level":"info","version":"237a920a04036c9cdea5aa0ebb1494de6c68e93c","time":"2023-10-10T18:42:17Z","message":"starting watchkeeper"}
{"level":"info","time":"2023-10-10T18:42:17Z","message":"loading cluster cidrs and kubeconfig"}
{"level":"info","channel":"#katesql-ops","time":"2023-10-10T18:42:18Z","message":"configured to send notifications to Slack"}
{"level":"info","component":"watcher","time":"2023-10-10T18:42:18Z","message":"waiting for zk tree cache initial sync"}
{"level":"info","time":"2023-10-10T18:42:18Z","message":"zk tree cache sync started"}
2023/10/10 18:42:18 connected to 242.7.226.10:2181
2023/10/10 18:42:18 authenticated: id=-6052798411968070523, timeout=10000
2023/10/10 18:42:18 re-submitting `0` credentials after reconnect
2023/10/10 18:42:23 synced tree cache in 4.613376465s
{"level":"info","elapsed":4613.376465,"time":"2023-10-10T18:42:23Z","message":"zk tree cache synced"}
```