### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,13 +6,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-    - name: Setup Go
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.22.3
-
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v6
+
+    - name: Setup Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
 
     - name: Run Lint
       run: make lint

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -7,26 +7,26 @@ jobs:
     strategy:
       matrix:
         zk-version: [ 3.6.2 ]
-        go-version: [ 1.22.x ]
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v6
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version-file: go.mod
 
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v5
       with:
-        java-version: 14
-
-    - name: Checkout code
-      uses: actions/checkout@v1
+        distribution: temurin
+        java-version: 25
 
     - name: Test code
       run: make test ZK_VERSION=${{ matrix.zk-version }}
 
     - name: Upload code coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v5
       with:
-        file: ./profile.cov
+        files: ./profile.cov


### PR DESCRIPTION
## Summary
- Bump all GitHub Actions to latest major versions: `actions/setup-go@v6`, `actions/checkout@v6`, `actions/setup-java@v5`, `codecov/codecov-action@v5`
- Use `go-version-file: go.mod` instead of hardcoded Go versions so CI always matches the project's Go version
- Move checkout step before setup-go so `go.mod` is available for version resolution
- Fix codecov input `file` → `files` (breaking change in v5)
- Update Java from 14 to 25 (latest LTS)

## Test plan
- [ ] Verify lint workflow runs successfully on a PR
- [ ] Verify unittest workflow runs and uploads coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)